### PR TITLE
manifest: track msm8994 hardware

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -357,6 +357,7 @@
   <project path="hardware/qcom/media-caf/msm8974" name="hardware_qcom_media" remote="aospb" revision="mm6.0-caf-8974" />
   <project path="hardware/qcom/media-caf/msm8994" name="hardware_qcom_media" remote="aospb" revision="mm6.0-caf-8994" />
   <project path="hardware/qcom/msm8960" name="platform/hardware/qcom/msm8960" groups="qcom_msm8960" />
+  <project path="hardware/qcom/msm8994" name="platform/hardware/qcom/msm8994" groups="qcom_msm8994" />
   <project path="hardware/qcom/msm8x26" name="platform/hardware/qcom/msm8x26" groups="qcom_msm8x26" />
   <project path="hardware/qcom/msm8x27" name="platform/hardware/qcom/msm8x27" groups="qcom_msm8x27" />
   <project path="hardware/qcom/msm8x74" name="platform/hardware/qcom/msm8x74" groups="pdk,qcom_msm8x74" />


### PR DESCRIPTION
device/lge/bullhead/dataservices/rmnetctl/src/librmnetctl.c:50:30: fatal error: linux/rmnet_data.h: No such file or directory
 #include <linux/rmnet_data.h>

Fixes that missing header when building for Nexus 5X (bullhead)
Probably needed for other devices like angler too
